### PR TITLE
Fix nil panic wrt handling the photo field

### DIFF
--- a/handlers/statsManager.go
+++ b/handlers/statsManager.go
@@ -212,8 +212,14 @@ func (sm *StatsManager) generateSpeakers(output *unmarshalledData, speakers []mo
 
 func (sm *StatsManager) generateMeetupGroups(output *unmarshalledData, meetupGroups []models.MeetupGroupIn) {
 	for _, group := range meetupGroups {
+		// Avoid nil panics if the meetup group doesn't have a photo
+		photo := ""
+		if group.Photo != nil {
+			photo = *group.Photo
+		}
+
 		newMeetupGroup := &models.MeetupGroup{
-			Photo:       *group.Photo,
+			Photo:       photo,
 			Name:        *group.Name,
 			City:        *group.City,
 			Country:     *group.Country,


### PR DESCRIPTION
cc @netumoliver @kaspernissen 

This happened when adding the Stavanger meetup group, as they don't have a photo attached:

```
I0210 15:21:39.675486    3057 schema.go:10] Creating database schema
I0210 15:21:39.675598    3057 statsManager.go:116] Fetching stats.json from: https://raw.githubusercontent.com/cloud-native-nordics/meetups/master/config.json
I0210 15:21:40.358316    3057 statsManager.go:149] Writing stats.json to: ./data/stats.json
I0210 15:21:40.406641    3057 statsManager.go:166] Unmarhsalling stats.json
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x812f36]

goroutine 1 [running]:
github.com/cloud-native-nordics/stats-api/handlers.(*StatsManager).generateMeetupGroups(0xc0000b8600, 0xc000154680, 0xc000105000, 0xd, 0xd)
        /home/lucas/luxas/OSS/stats-api/handlers/statsManager.go:216 +0xf6
github.com/cloud-native-nordics/stats-api/handlers.(*StatsManager).unmarshallData(0xc0000b8600, 0x0, 0x0, 0xdc23e0)
        /home/lucas/luxas/OSS/stats-api/handlers/statsManager.go:176 +0x1f8
github.com/cloud-native-nordics/stats-api/handlers.(*StatsManager).populateDBFromURL(0xc0000b8600)
        /home/lucas/luxas/OSS/stats-api/handlers/statsManager.go:102 +0xc2
github.com/cloud-native-nordics/stats-api/handlers.NewStatsManager(0x9a735e, 0x51, 0x45d964b800, 0x4)
        /home/lucas/luxas/OSS/stats-api/handlers/statsManager.go:66 +0xe1
main.main()
        /home/lucas/luxas/OSS/stats-api/main.go:48 +0x73f
```

This PR allows Photo to be unset, without panicing :joy: